### PR TITLE
Investigate the options for recursively processing directories

### DIFF
--- a/assets/html/index.html
+++ b/assets/html/index.html
@@ -30,7 +30,19 @@
         </nav>
 
         <div class="container">
-            <div class="alert alert-warning" role="alert">
+            <div id="directory-support-warning" class="alert alert-warning alert-dismissible" role="alert" hidden>
+                <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+
+                The browser which you are using allows the selection of or dropping multiple files.
+                Unfortunately, support for nested folders requires a web API which is currently only
+                available on Google Chrome.
+
+                See <a href="https://github.com/loc-rdc/bagger-js/pull/1">issue #1</a> for more information.
+            </div>
+
+            <div class="alert alert-info alert-dismissible" role="alert">
+                <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+
                 This is still a proof of concept: no files are actually transferred but you can download the
                 manifests
             </div>

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -199,7 +199,6 @@
         }
     }
 
-
     dropZone.querySelector('input[type="file"]').addEventListener('change', function () {
         dropZone.classList.add('active');
         handleFiles(this.files);
@@ -243,4 +242,8 @@
     dropZone.addEventListener('dragend', function () {
         dropZone.classList.remove('active');
     }, false);
+
+    if (typeof DataTransferItemList === 'undefined') {
+        document.getElementById('directory-support-warning').removeAttribute('hidden');
+    }
 })();


### PR DESCRIPTION
There is currently no standard way to handle directories.

Chrome:
- The [File API: Directories and System](http://www.w3.org/TR/file-system-api/) spec has stalled in the standards track but has been implemented in Chrome 21+ and Opera since the Blink switch

Mozilla: unsupported
- https://bugzilla.mozilla.org/show_bug.cgi?id=876480 suggests https://w3c.github.io/filesystem-api/Overview.html may lead to a solution
- Mozilla is now implementing Microsoft's much simpler proposal: https://bugzilla.mozilla.org/show_bug.cgi?id=1164310

IE: unsupported but under development
- https://status.modern.ie/draganddropdirectories
- https://wpdev.uservoice.com/forums/257854-internet-explorer-platform/suggestions/6261304-drag-and-drop-directories
- https://lists.w3.org/Archives/Public/public-webapps/2015AprJun/0245.html and simplified proposal: https://microsoftedge.github.io/directory-upload/proposal.html
